### PR TITLE
Fix basic ticket not routing to soldout

### DIFF
--- a/src/Pages/TicketDisplay.jsx
+++ b/src/Pages/TicketDisplay.jsx
@@ -30,7 +30,7 @@ const ticketTiers = [
   {
     name: "Basic Ticket",
     id: "tier-basic",
-    href: "/basic-ticket",
+    href: "/soldout",
     
     description: [
       "Access to speakers and presentations",


### PR DESCRIPTION
Update Basic Ticket href to `/soldout` to correctly reflect its sold-out status.

---
<a href="https://cursor.com/background-agent?bcId=bc-b697b8c0-51ed-44a6-a4f8-e61673908bfe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b697b8c0-51ed-44a6-a4f8-e61673908bfe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

